### PR TITLE
Feat: added snackbar positioning classes

### DIFF
--- a/Stylesheets/Components/toast.css
+++ b/Stylesheets/Components/toast.css
@@ -1,35 +1,72 @@
-.snack-bar{
-    max-width:25rem;
+.snack-bar {
+    max-width: 25rem;
     max-height: 7rem;
     min-width: 26rem;
     max-height: 4rem;
     background-color: var(--st-primary-hover);
     border-radius: 4px;
     margin: 8px;
+}
+
+.bottom-center {
     position: fixed;
     bottom: 0;
     right: 50%;
 }
 
-.content{
+.bottom-right {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+}
+
+.bottom-left {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+}
+
+.top-center {
+    position: fixed;
+    top: 0;
+    right: 50%;
+}
+
+.top-left {
+    position: fixed;
+    top: 0;
+    left: 0;
+}
+
+.top-right {
+    position: fixed;
+    top: 0;
+    right: 0;
+}
+
+.content {
     color: var(--st-background-grey);
     font-size: .875rem;
     line-height: 1.25rem;
     font-weight: 6px;
 }
-.btns{
+
+.btns {
     display: inline-flex;
     justify-content: space-around;
 }
-#retry{
-    color:var(--st-secondary-hover);
+
+.retry {
+    color: var(--st-secondary-hover);
     font-size: 0.9rem;
     font-weight: bold;
 }
-#close{
+
+.close {
     color: var(--st-white);
     font-weight: bold;
 }
-.margin-center{
+
+.margin-center {
     margin: 9.6px 6.4px;
 }


### PR DESCRIPTION
This is under the issue no. : #15 (https://github.com/rittik-ghosh/Maximus-UI/issues/15)
The following 6 classes have been added to the css file to make the toast act more flexible.
1)bottom-center
2)bottom-right
3)bottom-left
4)top-center
5)top-right
6)top-left.
Please review it and let me know if any improvements are to be made.

![toast (2)](https://user-images.githubusercontent.com/83537194/153630677-b352a9be-472b-4fb2-b36f-c0b9e4a4de09.PNG)
